### PR TITLE
 Add cookie allocation, sharing, and schedstats support

### DIFF
--- a/OS_0.01/fclt_sec0/buff_str.c
+++ b/OS_0.01/fclt_sec0/buff_str.c
@@ -1,0 +1,246 @@
+#include <linux/config.h>
+#include <linux/sched.h>
+#include <linux/kernel.h>
+#include <asm/system.h>
+
+#if (BUFFER_END & 0xfff)
+#error "Bad BUFFER_END value"
+#endif
+
+#if (BUFFER_END > 0xA0000 && BUFFER_END <= 0x100000)
+#error "Bad BUFFER_END value"
+#endif
+
+extern int end;
+struct buffer_head * start_buffer = (struct buffer_head *) &end;
+struct buffer_head * hash_table[NR_HASH];
+static struct buffer_head * free_list;
+static struct task_struct * buffer_wait = NULL;
+int NR_BUFFERS = 0;
+
+static inline void wait_on_buffer(struct buffer_head * bh)
+{
+	cli();
+	while (bh->b_lock)
+		sleep_on(&bh->b_wait);
+	sti();
+}
+
+int sys_sync(void)
+{
+	int i;
+	struct buffer_head * bh;
+
+	sync_inodes();		/* write out inodes into buffers */
+	bh = start_buffer;
+	for (i=0 ; i<NR_BUFFERS ; i++,bh++) {
+		wait_on_buffer(bh);
+		if (bh->b_dirt)
+			ll_rw_block(WRITE,bh);
+	}
+	return 0;
+}
+
+static int sync_dev(int dev)
+{
+	int i;
+	struct buffer_head * bh;
+
+	bh = start_buffer;
+	for (i=0 ; i<NR_BUFFERS ; i++,bh++) {
+		if (bh->b_dev != dev)
+			continue;
+		wait_on_buffer(bh);
+		if (bh->b_dirt)
+			ll_rw_block(WRITE,bh);
+	}
+	return 0;
+}
+
+#define _hashfn(dev,block) (((unsigned)(dev^block))%NR_HASH)
+#define hash(dev,block) hash_table[_hashfn(dev,block)]
+
+static inline void remove_from_queues(struct buffer_head * bh)
+{
+/* remove from hash-queue */
+	if (bh->b_next)
+		bh->b_next->b_prev = bh->b_prev;
+	if (bh->b_prev)
+		bh->b_prev->b_next = bh->b_next;
+	if (hash(bh->b_dev,bh->b_blocknr) == bh)
+		hash(bh->b_dev,bh->b_blocknr) = bh->b_next;
+/* remove from free list */
+	if (!(bh->b_prev_free) || !(bh->b_next_free))
+		panic("Free block list corrupted");
+	bh->b_prev_free->b_next_free = bh->b_next_free;
+	bh->b_next_free->b_prev_free = bh->b_prev_free;
+	if (free_list == bh)
+		free_list = bh->b_next_free;
+}
+
+static inline void insert_into_queues(struct buffer_head * bh)
+{
+/* put at end of free list */
+	bh->b_next_free = free_list;
+	bh->b_prev_free = free_list->b_prev_free;
+	free_list->b_prev_free->b_next_free = bh;
+	free_list->b_prev_free = bh;
+/* put the buffer in new hash-queue if it has a device */
+	bh->b_prev = NULL;
+	bh->b_next = NULL;
+	if (!bh->b_dev)
+		return;
+	bh->b_next = hash(bh->b_dev,bh->b_blocknr);
+	hash(bh->b_dev,bh->b_blocknr) = bh;
+	bh->b_next->b_prev = bh;
+}
+
+static struct buffer_head * find_buffer(int dev, int block)
+{		
+	struct buffer_head * tmp;
+
+	for (tmp = hash(dev,block) ; tmp != NULL ; tmp = tmp->b_next)
+		if (tmp->b_dev==dev && tmp->b_blocknr==block)
+			return tmp;
+	return NULL;
+}
+
+/*
+ * Why like this, I hear you say... The reason is race-conditions.
+ * As we don't lock buffers (unless we are readint them, that is),
+ * something might happen to it while we sleep (ie a read-error
+ * will force it bad). This shouldn't really happen currently, but
+ * the code is ready.
+ */
+struct buffer_head * get_hash_table(int dev, int block)
+{
+	struct buffer_head * bh;
+
+repeat:
+	if (!(bh=find_buffer(dev,block)))
+		return NULL;
+	bh->b_count++;
+	wait_on_buffer(bh);
+	if (bh->b_dev != dev || bh->b_blocknr != block) {
+		brelse(bh);
+		goto repeat;
+	}
+	return bh;
+}
+
+/*
+ * Ok, this is getblk, and it isn't very clear, again to hinder
+ * race-conditions. Most of the code is seldom used, (ie repeating),
+ * so it should be much more efficient than it looks.
+ */
+struct buffer_head * getblk(int dev,int block)
+{
+	struct buffer_head * tmp;
+
+repeat:
+	if (tmp=get_hash_table(dev,block))
+		return tmp;
+	tmp = free_list;
+	do {
+		if (!tmp->b_count) {
+			wait_on_buffer(tmp);	/* we still have to wait */
+			if (!tmp->b_count)	/* on it, it might be dirty */
+				break;
+		}
+		tmp = tmp->b_next_free;
+	} while (tmp != free_list || (tmp=NULL));
+	/* Kids, don't try THIS at home ^^^^^. Magic */
+	if (!tmp) {
+		printk("Sleeping on free buffer ..");
+		sleep_on(&buffer_wait);
+		printk("ok\n");
+		goto repeat;
+	}
+	tmp->b_count++;
+	remove_from_queues(tmp);
+/*
+ * Now, when we know nobody can get to this node (as it's removed from the
+ * free list), we write it out. We can sleep here without fear of race-
+ * conditions.
+ */
+	if (tmp->b_dirt)
+		sync_dev(tmp->b_dev);
+/* update buffer contents */
+	tmp->b_dev=dev;
+	tmp->b_blocknr=block;
+	tmp->b_dirt=0;
+	tmp->b_uptodate=0;
+/* NOTE!! While we possibly slept in sync_dev(), somebody else might have
+ * added "this" block already, so check for that. Thank God for goto's.
+ */
+	if (find_buffer(dev,block)) {
+		tmp->b_dev=0;		/* ok, someone else has beaten us */
+		tmp->b_blocknr=0;	/* to it - free this block and */
+		tmp->b_count=0;		/* try again */
+		insert_into_queues(tmp);
+		goto repeat;
+	}
+/* and then insert into correct position */
+	insert_into_queues(tmp);
+	return tmp;
+}
+
+void brelse(struct buffer_head * buf)
+{
+	if (!buf)
+		return;
+	wait_on_buffer(buf);
+	if (!(buf->b_count--))
+		panic("Trying to free free buffer");
+	wake_up(&buffer_wait);
+}
+
+/*
+ * bread() reads a specified block and returns the buffer that contains
+ * it. It returns NULL if the block was unreadable.
+ */
+struct buffer_head * bread(int dev,int block)
+{
+	struct buffer_head * bh;
+
+	if (!(bh=getblk(dev,block)))
+		panic("bread: getblk returned NULL\n");
+	if (bh->b_uptodate)
+		return bh;
+	ll_rw_block(READ,bh);
+	if (bh->b_uptodate)
+		return bh;
+	brelse(bh);
+	return (NULL);
+}
+
+void buffer_init(void)
+{
+	struct buffer_head * h = start_buffer;
+	void * b = (void *) BUFFER_END;
+	int i;
+
+	while ( (b -= BLOCK_SIZE) >= ((void *) (h+1)) ) {
+		h->b_dev = 0;
+		h->b_dirt = 0;
+		h->b_count = 0;
+		h->b_lock = 0;
+		h->b_uptodate = 0;
+		h->b_wait = NULL;
+		h->b_next = NULL;
+		h->b_prev = NULL;
+		h->b_data = (char *) b;
+		h->b_prev_free = h-1;
+		h->b_next_free = h+1;
+		h++;
+		NR_BUFFERS++;
+		if (b == (void *) 0x100000)
+			b = (void *) 0xA0000;
+	}
+	h--;
+	free_list = start_buffer;
+	free_list->b_prev_free = h;
+	h->b_next_free = free_list;
+	for (i=0;i<NR_HASH;i++)
+		hash_table[i]=NULL;
+}	

--- a/OS_0.01/fclt_sec0/dev_b.c
+++ b/OS_0.01/fclt_sec0/dev_b.c
@@ -1,0 +1,86 @@
+#include <errno.h>
+
+#include <linux/fs.h>
+#include <linux/kernel.h>
+#include <asm/segment.h>
+
+#define NR_BLK_DEV ((sizeof (rd_blk))/(sizeof (rd_blk[0])))
+
+int block_write(int dev, long * pos, char * buf, int count)
+{
+	int block = *pos / BLOCK_SIZE;
+	int offset = *pos % BLOCK_SIZE;
+	int chars;
+	int written = 0;
+	struct buffer_head * bh;
+	register char * p;
+
+	while (count>0) {
+		bh = bread(dev,block);
+		if (!bh)
+			return written?written:-EIO;
+		chars = (count<BLOCK_SIZE) ? count : BLOCK_SIZE;
+		p = offset + bh->b_data;
+		offset = 0;
+		block++;
+		*pos += chars;
+		written += chars;
+		count -= chars;
+		while (chars-->0)
+			*(p++) = get_fs_byte(buf++);
+		bh->b_dirt = 1;
+		brelse(bh);
+	}
+	return written;
+}
+
+int block_read(int dev, unsigned long * pos, char * buf, int count)
+{
+	int block = *pos / BLOCK_SIZE;
+	int offset = *pos % BLOCK_SIZE;
+	int chars;
+	int read = 0;
+	struct buffer_head * bh;
+	register char * p;
+
+	while (count>0) {
+		bh = bread(dev,block);
+		if (!bh)
+			return read?read:-EIO;
+		chars = (count<BLOCK_SIZE) ? count : BLOCK_SIZE;
+		p = offset + bh->b_data;
+		offset = 0;
+		block++;
+		*pos += chars;
+		read += chars;
+		count -= chars;
+		while (chars-->0)
+			put_fs_byte(*(p++),buf++);
+		bh->b_dirt = 1;
+		brelse(bh);
+	}
+	return read;
+}
+
+extern void rw_hd(int rw, struct buffer_head * bh);
+
+typedef void (*blk_fn)(int rw, struct buffer_head * bh);
+
+static blk_fn rd_blk[]={
+	NULL,		/* nodev */
+	NULL,		/* dev mem */
+	NULL,		/* dev fd */
+	rw_hd,		/* dev hd */
+	NULL,		/* dev ttyx */
+	NULL,		/* dev tty */
+	NULL};		/* dev lp */
+
+void ll_rw_block(int rw, struct buffer_head * bh)
+{
+	blk_fn blk_addr;
+	unsigned int major;
+
+	if ((major=MAJOR(bh->b_dev)) >= NR_BLK_DEV || !(blk_addr=rd_blk[major]))
+		panic("Trying to read nonexistent block-device");
+	blk_addr(rw, bh);
+}

--- a/OS_0.01/fclt_sec0/function.c
+++ b/OS_0.01/fclt_sec0/function.c
@@ -1,0 +1,69 @@
+#include <string.h>
+#include <errno.h>
+#include <linux/sched.h>
+#include <linux/kernel.h>
+#include <asm/segment.h>
+
+#include <linux/fcntl.h>
+#include <sys/stat.h>
+
+extern int sys_close(int fd);
+
+static int dupfd(unsigned int fd, unsigned int arg)
+{
+	if (fd >= NR_OPEN || !current->filp[fd])
+		return -EBADF;
+	if (arg >= NR_OPEN)
+		return -EINVAL;
+	while (arg < NR_OPEN)
+		if (current->filp[arg])
+			arg++;
+		else
+			break;
+	if (arg >= NR_OPEN)
+		return -EMFILE;
+	current->close_on_exec &= ~(1<<arg);
+	(current->filp[arg] = current->filp[fd])->f_count++;
+	return arg;
+}
+
+int sys_dup2(unsigned int oldfd, unsigned int newfd)
+{
+	sys_close(newfd);
+	return dupfd(oldfd,newfd);
+}
+
+int sys_dup(unsigned int fildes)
+{
+	return dupfd(fildes,0);
+}
+
+int sys_fcntl(unsigned int fd, unsigned int cmd, unsigned long arg)
+{	
+	struct file * filp;
+
+	if (fd >= NR_OPEN || !(filp = current->filp[fd]))
+		return -EBADF;
+	switch (cmd) {
+		case F_DUPFD:
+			return dupfd(fd,arg);
+		case F_GETFD:
+			return (current->close_on_exec>>fd)&1;
+		case F_SETFD:
+			if (arg&1)
+				current->close_on_exec |= (1<<fd);
+			else
+				current->close_on_exec &= ~(1<<fd);
+			return 0;
+		case F_GETFL:
+			return filp->f_flags;
+		case F_SETFL:
+			filp->f_flags &= ~(O_APPEND | O_NONBLOCK);
+			filp->f_flags |= arg & (O_APPEND | O_NONBLOCK);
+			return 0;
+		case F_GETLK:	case F_SETLK:	case F_SETLKW:
+			return -1;
+		default:
+			return -1;
+	}
+}

--- a/OS_0.01/init_sec0/core.h
+++ b/OS_0.01/init_sec0/core.h
@@ -1,0 +1,85 @@
+#include <linux/sched/affinity.h>
+#include <linux/sched/autogroup.h>
+#include <linux/sched/cpufreq.h>
+#include <linux/sched/deadline.h>
+#include <linux/sched.h>
+#include <linux/sched/loadavg.h>
+#include <linux/sched/mm.h>
+#include <linux/sched/rseq_api.h>
+#include <linux/sched/signal.h>
+#include <linux/sched/smt.h>
+#include <linux/sched/stat.h>
+#include <linux/sched/sysctl.h>
+#include <linux/sched/task_flags.h>
+#include <linux/sched/task.h>
+#include <linux/sched/topology.h>
+#include <linux/atomic.h>
+
+
+struct rq;
+struct cfs_rq;
+struct rt_rq;
+struct sched_group;
+struct cpuidle_state;
+
+#ifdef CONFIG_PARAVIRT
+# include <asm/paravirt.h>
+# include <asm/paravirt_api_clock.h>
+#endif
+
+#include <asm/barrier.h>
+
+#include "cpupri.h"
+#include "cpudeadline.h"
+
+/* task_struct::on_rq states: */
+#define TASK_ON_RQ_QUEUED	1
+#define TASK_ON_RQ_MIGRATING	2
+
+extern __read_mostly int scheduler_running;
+
+extern unsigned long calc_load_update;
+extern atomic_long_t calc_load_tasks;
+
+extern void calc_global_load_tick(struct rq *this_rq);
+extern long calc_load_fold_active(struct rq *this_rq, long adjust);
+
+extern void call_trace_sched_update_nr_running(struct rq *rq, int count);
+
+extern int sysctl_sched_rt_period;
+extern int sysctl_sched_rt_runtime;
+extern int sched_rr_timeslice;
+
+/*
+ * Asymmetric CPU capacity bits
+ */
+struct asym_cap_data {
+	struct list_head link;
+	struct rcu_head rcu;
+	unsigned long capacity;
+	unsigned long cpus[];
+};
+
+extern struct list_head asym_cap_list;
+
+#define cpu_capacity_span(asym_data) to_cpumask((asym_data)->cpus);
+
+/*
+ * Helpers for converting nanosecond timing to jiffy resolution
+ */
+#define NS_TO_JIFFIES(time)	((unsigned long)(time) / (NSEC_PER_SEC/HZ));
+
+static inline int task_has_idle_policy(struct task_struct *p)
+{
+	return idle_policy(p->policy);
+}
+
+static inline int task_has_rt_policy(struct task_struct *p)
+{
+	return rt_policy(p->policy);
+}
+
+static inline int task_has_dl_policy(struct task_struct *p)
+{
+	return dl_policy(p->policy);
+}

--- a/OS_0.01/init_sec0/cpu_core.c
+++ b/OS_0.01/init_sec0/cpu_core.c
@@ -1,0 +1,271 @@
+
+#include "core.h"
+
+struct sched_core_cookie {
+	refcount_t refcnt;
+};
+
+static unsigned long sched_core_alloc_cookie(void)
+{
+	struct sched_core_cookie *ck = kmalloc(sizeof(*ck), GFP_KERNEL);
+	if (!ck)
+		return 0;
+
+	refcount_set(&ck->refcnt, 1);
+	sched_core_get();
+
+	return (unsigned long)ck;
+}
+
+static void sched_core_put_cookie(unsigned long cookie)
+{
+	struct sched_core_cookie *ptr = (void *)cookie;
+
+	if (ptr && refcount_dec_and_test(&ptr->refcnt)) {
+		kfree(ptr);
+		sched_core_put();
+	}
+}
+
+static unsigned long sched_core_get_cookie(unsigned long cookie)
+{
+	struct sched_core_cookie *ptr = (void *)cookie;
+
+	if (ptr)
+		refcount_inc(&ptr->refcnt);
+
+	return cookie;
+}
+
+static unsigned long sched_core_update_cookie(struct task_struct *p,
+					      unsigned long cookie)
+{
+	unsigned long old_cookie;
+	struct rq_flags rf;
+	struct rq *rq;
+
+	rq = task_rq_lock(p, &rf);
+
+
+	WARN_ON_ONCE((p->core_cookie || cookie) && !sched_core_enabled(rq));
+
+	if (sched_core_enqueued(p))
+		sched_core_dequeue(rq, p, DEQUEUE_SAVE);
+
+	old_cookie = p->core_cookie;
+	p->core_cookie = cookie;
+
+	/*
+	 * Consider the cases: !prev_cookie and !cookie.
+	 */
+	if (cookie && task_on_rq_queued(p))
+		sched_core_enqueue(rq, p);
+
+
+	if (task_on_cpu(rq, p))
+		resched_curr(rq);
+
+	task_rq_unlock(rq, p, &rf);
+
+	return old_cookie;
+}
+
+static unsigned long sched_core_clone_cookie(struct task_struct *p)
+{
+	unsigned long cookie, flags;
+
+	raw_spin_lock_irqsave(&p->pi_lock, flags);
+	cookie = sched_core_get_cookie(p->core_cookie);
+	raw_spin_unlock_irqrestore(&p->pi_lock, flags);
+
+	return cookie;
+}
+
+void sched_core_fork(struct task_struct *p)
+{
+	RB_CLEAR_NODE(&p->core_node);
+	p->core_cookie = sched_core_clone_cookie(current);
+}
+
+void sched_core_free(struct task_struct *p)
+{
+	sched_core_put_cookie(p->core_cookie);
+}
+
+static void __sched_core_set(struct task_struct *p, unsigned long cookie)
+{
+	cookie = sched_core_get_cookie(cookie);
+	cookie = sched_core_update_cookie(p, cookie);
+	sched_core_put_cookie(cookie);
+}
+
+/* Called from prctl interface: PR_SCHED_CORE */
+int sched_core_share_pid(unsigned int cmd, pid_t pid, enum pid_type type,
+			 unsigned long uaddr)
+{
+	unsigned long cookie = 0, id = 0;
+	struct task_struct *task, *p;
+	struct pid *grp;
+	int err = 0;
+
+	if (!static_branch_likely(&sched_smt_present))
+		return -ENODEV;
+
+	BUILD_BUG_ON(PR_SCHED_CORE_SCOPE_THREAD != PIDTYPE_PID);
+	BUILD_BUG_ON(PR_SCHED_CORE_SCOPE_THREAD_GROUP != PIDTYPE_TGID);
+	BUILD_BUG_ON(PR_SCHED_CORE_SCOPE_PROCESS_GROUP != PIDTYPE_PGID);
+
+	if (type > PIDTYPE_PGID || cmd >= PR_SCHED_CORE_MAX || pid < 0 ||
+	    (cmd != PR_SCHED_CORE_GET && uaddr))
+		return -EINVAL;
+
+	rcu_read_lock();
+	if (pid == 0) {
+		task = current;
+	} else {
+		task = find_task_by_vpid(pid);
+		if (!task) {
+			rcu_read_unlock();
+			return -ESRCH;
+		}
+	}
+	get_task_struct(task);
+	rcu_read_unlock();
+
+
+	if (!ptrace_may_access(task, PTRACE_MODE_READ_REALCREDS)) {
+		err = -EPERM;
+		goto out;
+	}
+
+	switch (cmd) {
+	case PR_SCHED_CORE_GET:
+		if (type != PIDTYPE_PID || uaddr & 7) {
+			err = -EINVAL;
+			goto out;
+		}
+		cookie = sched_core_clone_cookie(task);
+		if (cookie) {
+			/* XXX improve ? */
+			ptr_to_hashval((void *)cookie, &id);
+		}
+		err = put_user(id, (u64 __user *)uaddr);
+		goto out;
+
+	case PR_SCHED_CORE_CREATE:
+		cookie = sched_core_alloc_cookie();
+		if (!cookie) {
+			err = -ENOMEM;
+			goto out;
+		}
+		break;
+
+	case PR_SCHED_CORE_SHARE_TO:
+		cookie = sched_core_clone_cookie(current);
+		break;
+
+	case PR_SCHED_CORE_SHARE_FROM:
+		if (type != PIDTYPE_PID) {
+			err = -EINVAL;
+			goto out;
+		}
+		cookie = sched_core_clone_cookie(task);
+		__sched_core_set(current, cookie);
+		goto out;
+
+	default:
+		err = -EINVAL;
+		goto out;
+	}
+
+	if (type == PIDTYPE_PID) {
+		__sched_core_set(task, cookie);
+		goto out;
+	}
+
+	read_lock(&tasklist_lock);
+	grp = task_pid_type(task, type);
+
+	do_each_pid_thread(grp, type, p) {
+		if (!ptrace_may_access(p, PTRACE_MODE_READ_REALCREDS)) {
+			err = -EPERM;
+			goto out_tasklist;
+		}
+	} while_each_pid_thread(grp, type, p);
+
+	do_each_pid_thread(grp, type, p) {
+		__sched_core_set(p, cookie);
+	} while_each_pid_thread(grp, type, p);
+out_tasklist:
+	read_unlock(&tasklist_lock);
+
+out:
+	sched_core_put_cookie(cookie);
+	put_task_struct(task);
+	return err;
+}
+
+#ifdef CONFIG_SCHEDSTATS
+
+/* REQUIRES: rq->core's clock recently updated. */
+void __sched_core_account_forceidle(struct rq *rq)
+{
+	const struct cpumask *smt_mask = cpu_smt_mask(cpu_of(rq));
+	u64 delta, now = rq_clock(rq->core);
+	struct rq *rq_i;
+	struct task_struct *p;
+	int i;
+
+	lockdep_assert_rq_held(rq);
+
+	WARN_ON_ONCE(!rq->core->core_forceidle_count);
+
+	if (rq->core->core_forceidle_start == 0)
+		return;
+
+	delta = now - rq->core->core_forceidle_start;
+	if (unlikely((s64)delta <= 0))
+		return;
+
+	rq->core->core_forceidle_start = now;
+
+	if (WARN_ON_ONCE(!rq->core->core_forceidle_occupation)) {
+		/* can't be forced idle without a running task */
+	} else if (rq->core->core_forceidle_count > 1 ||
+		   rq->core->core_forceidle_occupation > 1) {
+		/*
+		 * For larger SMT configurations, we need to scale the charged
+		 * forced idle amount since there can be more than one forced
+		 * idle sibling and more than one running cookied task.
+		 */
+		delta *= rq->core->core_forceidle_count;
+		delta = div_u64(delta, rq->core->core_forceidle_occupation);
+	}
+
+	for_each_cpu(i, smt_mask) {
+		rq_i = cpu_rq(i);
+		p = rq_i->core_pick ?: rq_i->curr;
+
+		if (p == rq_i->idle)
+			continue;
+
+		/*
+		 * Note: this will account forceidle to the current CPU, even
+		 * if it comes from our SMT sibling.
+		 */
+		__account_forceidle_time(p, delta);
+	}
+}
+
+void __sched_core_tick(struct rq *rq)
+{
+	if (!rq->core->core_forceidle_count)
+		return;
+
+	if (rq != rq->core)
+		update_rq_clock(rq->core);
+
+	__sched_core_account_forceidle(rq);
+}
+
+#endif 

--- a/OS_0.01/init_sec0/cpu_core.c
+++ b/OS_0.01/init_sec0/cpu_core.c
@@ -268,4 +268,4 @@ void __sched_core_tick(struct rq *rq)
 	__sched_core_account_forceidle(rq);
 }
 
-#endif 
+#endif

--- a/OS_0.01/init_sec0/path_Util.c
+++ b/OS_0.01/init_sec0/path_Util.c
@@ -1,13 +1,12 @@
 #include <linux/fcntl.h>
 #include <linux/file.h>
 #include <linux/fs.h>
-#include <linux/init_syscalls.h>
+#include <linux/init_syscalls.h> /* removed double call */
 #include <linux/init.h>
 #include <linux/async.h>
 #include <linux/export.h>
 #include <linux/slab.h>
 #include <linux/types.h>
-#include <linux/init_syscalls.h>
 #include <linux/umh.h>
 #include <linux/security.h>
 #include <linux/ctype.h>
@@ -19,7 +18,10 @@
 #include <linux/err.h>
 #include <linux/smp.h>
 #include <linux/delay.h>
-
+#include <linux/extable.h>
+#include <linux/module.h>
+#include <linux/proc_fs.h>
+#include <linux/binfmts.h>
 // Main kernel initialization entry
 // Sets up lowcore, idle threads, timers, initramfs, and initcalls
 
@@ -2489,6 +2491,7 @@ void smpboot_unregister_percpu_thread(struct smp_hotplug_thread *plug_thread)
 }
 EXPORT_SYMBOL_GPL(smpboot_unregister_percpu_thread);
 
+/* add-ons */
 static int zstd_decompress(struct acomp_req *req)
 {
 	struct crypto_acomp_stream *s;
@@ -2584,6 +2587,249 @@ unsigned int uclamp_rq_max_value(struct rq *rq, enum uclamp_id clamp_id,
 
 	/* No tasks default clamp values */
 	return uclamp_idle_value(rq, clamp_id, clamp_value);
+}
+
+static char * __init xbc_make_cmdline(const char *key)
+{
+	struct xbc_node *root;
+	char *new_cmdline;
+	int ret, len = 0;
+
+	root = xbc_find_node(key);
+	if (!root)
+		return NULL;
+
+	/* Count required buffer size */
+	len = xbc_snprint_cmdline(NULL, 0, root);
+	if (len <= 0)
+		return NULL;
+
+	new_cmdline = memblock_alloc(len + 1, SMP_CACHE_BYTES);
+	if (!new_cmdline) {
+		pr_err("Failed to allocate memory for extra kernel cmdline.\n");
+		return NULL;
+	}
+
+	ret = xbc_snprint_cmdline(new_cmdline, len + 1, root);
+	if (ret < 0 || ret > len) {
+		pr_err("Failed to print extra kernel cmdline.\n");
+		memblock_free(new_cmdline, len + 1);
+		return NULL;
+	}
+
+	return new_cmdline;
+}
+
+asmlinkage __visible __init __no_sanitize_address __noreturn __no_stack_protector
+void start_kernel(void)
+{
+	char *command_line;
+	char *after_dashes;
+
+	set_task_stack_end_magic(&init_task);
+	smp_setup_processor_id();
+	debug_objects_early_init();
+	init_vmlinux_build_id();
+
+	cgroup_init_early();
+
+	local_irq_disable();
+	early_boot_irqs_disabled = true;
+
+	/*
+	 * Interrupts are still disabled. Do necessary setups, then
+	 * enable them.
+	 */
+	boot_cpu_init();
+	page_address_init();
+	pr_notice("%s", linux_banner);
+	setup_arch(&command_line);
+	/* Static keys and static calls are needed by LSMs */
+	jump_label_init();
+	static_call_init();
+	early_security_init();
+	setup_boot_config();
+	setup_command_line(command_line);
+	setup_nr_cpu_ids();
+	setup_per_cpu_areas();
+	smp_prepare_boot_cpu();	/* arch-specific boot-cpu hooks */
+	early_numa_node_init();
+	boot_cpu_hotplug_init();
+
+	pr_notice("Kernel command line: %s\n", saved_command_line);
+	/* parameters may set static keys */
+	parse_early_param();
+	after_dashes = parse_args("Booting kernel",
+				  static_command_line, __start___param,
+				  __stop___param - __start___param,
+				  -1, -1, NULL, &unknown_bootoption);
+	print_unknown_bootoptions();
+	if (!IS_ERR_OR_NULL(after_dashes))
+		parse_args("Setting init args", after_dashes, NULL, 0, -1, -1,
+			   NULL, set_init_arg);
+	if (extra_init_args)
+		parse_args("Setting extra init args", extra_init_args,
+			   NULL, 0, -1, -1, NULL, set_init_arg);
+
+	/* Architectural and non-timekeeping rng init, before allocator init */
+	random_init_early(command_line);
+
+	/*
+	 * These use large bootmem allocations and must precede
+	 * initalization of page allocator
+	 */
+	setup_log_buf(0);
+	vfs_caches_init_early();
+	sort_main_extable();
+	trap_init();
+	mm_core_init();
+	poking_init();
+	ftrace_init();
+
+	/* trace_printk can be enabled here */
+	early_trace_init();
+
+	/*
+	 * Set up the scheduler prior starting any interrupts (such as the
+	 * timer interrupt). Full topology setup happens at smp_init()
+	 * time - but meanwhile we still have a functioning scheduler.
+	 */
+	sched_init();
+
+	if (WARN(!irqs_disabled(),
+		 "Interrupts were enabled *very* early, fixing it\n"))
+		local_irq_disable();
+	radix_tree_init();
+	maple_tree_init();
+
+	/*
+	 * Set up housekeeping before setting up workqueues to allow the unbound
+	 * workqueue to take non-housekeeping into account.
+	 */
+	housekeeping_init();
+
+	/*
+	 * Allow workqueue creation and work item queueing/cancelling
+	 * early.  Work item execution depends on kthreads and starts after
+	 * workqueue_init().
+	 */
+	workqueue_init_early();
+
+	rcu_init();
+	kvfree_rcu_init();
+
+	/* Trace events are available after this */
+	trace_init();
+
+	if (initcall_debug)
+		initcall_debug_enable();
+
+	context_tracking_init();
+	/* init some links before init_ISA_irqs() */
+	early_irq_init();
+	init_IRQ();
+	tick_init();
+	rcu_init_nohz();
+	timers_init();
+	srcu_init();
+	hrtimers_init();
+	softirq_init();
+	timekeeping_init();
+	time_init();
+
+	/* This must be after timekeeping is initialized */
+	random_init();
+
+	/* These make use of the fully initialized rng */
+	kfence_init();
+	boot_init_stack_canary();
+
+	perf_event_init();
+	profile_init();
+	call_function_init();
+	WARN(!irqs_disabled(), "Interrupts were enabled early\n");
+
+	early_boot_irqs_disabled = false;
+	local_irq_enable();
+
+	kmem_cache_init_late();
+
+	/*
+	 * HACK ALERT! This is early. We're enabling the console before
+	 * we've done PCI setups etc, and console_init() must be aware of
+	 * this. But we do want output early, in case something goes wrong.
+	 */
+	console_init();
+	if (panic_later)
+		panic("Too many boot %s vars at `%s'", panic_later,
+		      panic_param);
+
+	lockdep_init();
+
+	/*
+	 * Need to run this when irqs are enabled, because it wants
+	 * to self-test [hard/soft]-irqs on/off lock inversion bugs
+	 * too:
+	 */
+	locking_selftest();
+
+#ifdef CONFIG_BLK_DEV_INITRD
+	if (initrd_start && !initrd_below_start_ok &&
+	    page_to_pfn(virt_to_page((void *)initrd_start)) < min_low_pfn) {
+		pr_crit("initrd overwritten (0x%08lx < 0x%08lx) - disabling it.\n",
+		    page_to_pfn(virt_to_page((void *)initrd_start)),
+		    min_low_pfn);
+		initrd_start = 0;
+	}
+#endif
+	setup_per_cpu_pageset();
+	numa_policy_init();
+	acpi_early_init();
+	if (late_time_init)
+		late_time_init();
+	sched_clock_init();
+	calibrate_delay();
+
+	arch_cpu_finalize_init();
+
+	pid_idr_init();
+	anon_vma_init();
+	thread_stack_cache_init();
+	cred_init();
+	fork_init();
+	proc_caches_init();
+	uts_ns_init();
+	key_init();
+	security_init();
+	dbg_late_init();
+	net_ns_init();
+	vfs_caches_init();
+	pagecache_init();
+	signals_init();
+	seq_file_init();
+	proc_root_init();
+	nsfs_init();
+	pidfs_init();
+	cpuset_init();
+	mem_cgroup_init();
+	cgroup_init();
+	taskstats_init_early();
+	delayacct_init();
+
+	acpi_subsystem_init();
+	arch_post_acpi_subsys_init();
+	kcsan_init();
+
+	/* Do the rest non-__init'ed, we're now alive */
+	rest_init();
+
+	/*
+	 * Avoid stack canaries in callers of boot_init_stack_canary for gcc-10
+	 * and older.
+	 */
+#if !__has_attribute(__no_stack_protector__)
+	prevent_tail_call_optimization();
+#endif
 }
 
 //WTBD////

--- a/OS_0.01/init_sec0/path_Util.c
+++ b/OS_0.01/init_sec0/path_Util.c
@@ -2832,5 +2832,36 @@ void start_kernel(void)
 #endif
 }
 
+static int __init early_hostname(char *arg)
+{
+	size_t bufsize = sizeof(init_uts_ns.name.nodename);
+	size_t maxlen  = bufsize - 1;
+	ssize_t arglen;
+
+	arglen = strscpy(init_uts_ns.name.nodename, arg, bufsize);
+	if (arglen < 0) {
+		pr_warn("hostname parameter exceeds %zd characters and will be truncated",
+			maxlen);
+	}
+	return 0;
+}
+early_param("hostname", early_hostname);
+
+const char linux_proc_banner[] =
+	"%s version %s"
+	" (" LINUX_COMPILE_BY "@" LINUX_COMPILE_HOST ")"
+	" (" LINUX_COMPILER ") %s\n";
+
+BUILD_SALT;
+BUILD_LTO_INFO;
+
+
+struct uts_namespace init_uts_ns __weak;
+const char linux_banner[] __weak;
+
+#include "version-timestamp.c"
+
+EXPORT_SYMBOL_GPL(init_uts_ns);
+
 //WTBD////
 /* Soon */


### PR DESCRIPTION
Added struct sched_core_cookie with refcounting.

Implemented helpers for cookie lifecycle:

sched_core_alloc_cookie(), sched_core_put_cookie(), sched_core_get_cookie(), and sched_core_update_cookie().

Integrated cookie management into task lifecycle:

sched_core_fork() clones cookie from parent.

sched_core_free() releases cookie on exit.

Implemented __sched_core_set() for updating cookies safely.