### PR TITLE
FPU and Scheduler Improvements: Fix balance callbacks, refactor ldexpp(), and enhance IEEE-754 handling

### DIFF
--- a/OS_0.01/inc_sec0/idFr_e.c
+++ b/OS_0.01/inc_sec0/idFr_e.c
@@ -714,20 +714,25 @@ static inline void finish_task(struct task_struct *prev)
 
 static void do_balance_callbacks(struct rq *rq, struct balance_callback *head)
 {
-	void (*func)(struct rq *rq);
 	struct balance_callback *next;
 
 	lockdep_assert_rq_held(rq);
 
 	while (head) {
-		func = (void (*)(struct rq *))head->func;
+		/* Save next callback before invoking this one */
 		next = head->next;
-		head->next = NULL;
-		head = next;
 
-		func(rq);
+		/* Detach current callback from list to avoid accidental reuse */
+		head->next = NULL;
+
+		/* Invoke callback */
+		head->func(rq);
+
+		/* Move to next callback */
+		head = next;
 	}
 }
+
 
 static void balance_push(struct rq *rq);
 


### PR DESCRIPTION
ldexpp() (rewritten for x86 / IEEE-754 floats)
Uses bitwise extraction of sign, exponent, and mantissa via a union for portability.
Properly rebiases the exponent (bias = 127), with clamping for underflow/overflow.
Updates condition flags (FPZ, FPN, FPV, FPC) consistently across all FPU ops.
also,
int do_balance_callbacks() fixed traversal logic to safely iterate over callback lists.
